### PR TITLE
Allow multiple attributes for skip

### DIFF
--- a/src/transpiler/attributes-collector.js
+++ b/src/transpiler/attributes-collector.js
@@ -11,14 +11,14 @@ var AttributesCollector = function(parseOptions) {
     this.staticAttrs              = [];
     this.dynAttrs                 = [];
     this.hasSkipBlockAttribute    = false;
-    this.skipBlockAttributeMarker = parseOptions.skipBlockAttributeMarker;
+    this.skipBlockAttributeMarker = Array.isArray(parseOptions.skipBlockAttributeMarker) ? parseOptions.skipBlockAttributeMarker : [parseOptions.skipBlockAttributeMarker];
 };
 AttributesCollector.prototype.pushPair  = function(key, value) {
     var hasMoustache = key.indexOf(Constants.moustachePlaceholderPrefix) !== -1 || value.indexOf(Constants.moustachePlaceholderPrefix) !== -1;
     var isStatic     = (!hasMoustache && this.bcount === 0);
     var qualifier    = ATTRIBUTE_QUALIFIER;
     // skip block attribute can be static or dynamic
-    if(key === this.skipBlockAttributeMarker) {
+    if(this.skipBlockAttributeMarker.indexOf(key) !== -1) {
         this.hasSkipBlockAttribute = true;
         if(this.bcount > 0) {
             throw new Error('Unsupperted skip block ' + key + (value ? '=' + value : '' ) + ' inside a control block');


### PR DESCRIPTION
Because sometime you cannot re-write the templates you do not own, and you cannot add skip attributes dynamically *after* render the templates, so it would be nice to be able to set a list of skip attributes.

This change is not breaking regarding the actual api for options.